### PR TITLE
Redirects "test" target to standard "check" target

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -38,3 +38,6 @@ install-data-local: $(DATADIRS)
 download-data:
 	( cd $(srcdir) ; \
 	contrib/download_data; )
+
+test: check
+


### PR DESCRIPTION
I'm not sure why Travis would pick "test" over "check" in the `language: c` presets, but this fixes the failure.